### PR TITLE
fix(escape): escape html in text node

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -255,9 +255,13 @@
       3
     ],
     "max-len": [
-      2,
-      120,
-      4
+      2, {
+        "code": 120,
+        "tabWidth": 4,
+        "ignoreStrings": true,
+        "ignoreComments": true,
+        "ignoreRegExpLiterals": true
+      }
     ],
     "max-nested-callbacks": [
       2,

--- a/src/renderer.basic.js
+++ b/src/renderer.basic.js
@@ -26,7 +26,9 @@ var basicRenderer = Renderer.factory({
 
         managedText = this.trim(this.getSpaceCollapsedText(node.nodeValue));
 
-        if (this._isNeedEscape(managedText)) {
+        if (this._isNeedEscapeHtml(managedText)) {
+            managedText = this.escapeTextHtml(managedText);
+        } else if (this._isNeedEscape(managedText)) {
             managedText = this.escapeText(managedText);
         }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -308,6 +308,20 @@ Renderer.prototype.escapeText = function(text) {
     return text;
 };
 
+/**
+ * Backslash escape to text for html
+ * Apply backslash escape to text
+ * @param {string} text text be processed
+ * @returns {string} processed text
+ */
+Renderer.prototype.escapeTextHtml = function(text) {
+    text = text.replace(Renderer.markdownTextToEscapeHtmlRx, function(matched) {
+        return '\\' + matched;
+    });
+
+    return text;
+};
+
 Renderer.markdownTextToEscapeRx = {
     codeblock: /(^ {4}[^\n]+\n*)+/,
     hr: /^ *((\* *){3,}|(- *){3,} *|(_ *){3,}) */,
@@ -329,6 +343,8 @@ Renderer.markdownTextToEscapeRx = {
     codeblockGfm: /^(`{3,})/
 };
 
+Renderer.markdownTextToEscapeHtmlRx = /<([a-zA-Z_][a-zA-Z0-9\-\._]*)(\s|[^\\/>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-\._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-\.:/]*)>/g;
+
 Renderer.prototype._isNeedEscape = function(text) {
     var res = false;
     var markdownTextToEscapeRx = Renderer.markdownTextToEscapeRx;
@@ -342,6 +358,10 @@ Renderer.prototype._isNeedEscape = function(text) {
     }
 
     return res;
+};
+
+Renderer.prototype._isNeedEscapeHtml = function(text) {
+    return Renderer.markdownTextToEscapeHtmlRx.test(text);
 };
 
 /**

--- a/test/renderer.spec.js
+++ b/test/renderer.spec.js
@@ -194,6 +194,32 @@ describe('renderer', function() {
         expect(renderer.escapeText('im ` text')).toEqual('im \\` text');
     });
 
+    it('escapeTextHtml() can process html text node for markdown text', function() {
+        var renderer = Renderer.factory();
+
+        expect(renderer.escapeTextHtml('im <span> text')).toEqual('im \\<span> text');
+        expect(renderer.escapeTextHtml('im <span > text')).toEqual('im \\<span > text');
+        expect(renderer.escapeTextHtml('im <span /> text')).toEqual('im \\<span /> text');
+        expect(renderer.escapeTextHtml('im <SPAN> text')).toEqual('im \\<SPAN> text');
+        expect(renderer.escapeTextHtml('im </span> text')).toEqual('im \\</span> text');
+        expect(renderer.escapeTextHtml('im <span-custom> text')).toEqual('im \\<span-custom> text');
+        expect(renderer.escapeTextHtml('im <span attr="value"> text')).toEqual('im \\<span attr="value"> text');
+        expect(renderer.escapeTextHtml('im <prefix:span> text')).toEqual('im \\<prefix:span> text');
+        expect(renderer.escapeTextHtml('im <span.dot> text')).toEqual('im \\<span.dot> text');
+        expect(renderer.escapeTextHtml('im <!-- comment --> text')).toEqual('im \\<!-- comment --> text');
+
+        expect(renderer.escapeTextHtml('im <http://google.com> text')).toEqual('im \\<http://google.com> text');
+        expect(renderer.escapeTextHtml('im <mailto:foo@bar.baz> text')).toEqual('im \\<mailto:foo@bar.baz> text');
+
+        expect(renderer.escapeTextHtml('im <\\span> text')).toEqual('im <\\span> text');
+        expect(renderer.escapeTextHtml('im </ span> text')).toEqual('im </ span> text');
+        expect(renderer.escapeTextHtml('im </span attr="value"> text')).toEqual('im </span attr="value"> text');
+        expect(renderer.escapeTextHtml('im < span> text')).toEqual('im < span> text');
+        expect(renderer.escapeTextHtml('im <span/ > text')).toEqual('im <span/ > text');
+        expect(renderer.escapeTextHtml('im <http://foo.bar/baz bim> text')).toEqual('im <http://foo.bar/baz bim> text');
+        expect(renderer.escapeTextHtml('im <http://example.com/\\[> text')).toEqual('im <http://example.com/\\[> text');
+    });
+
     describe('_isNeedEscape() can check passed text is needed escape or not', function() {
         var renderer;
 
@@ -276,6 +302,42 @@ describe('renderer', function() {
             expect(renderer._isNeedEscape('[]!(#)')).toEqual(false);
             expect(renderer._isNeedEscape('[avafwef]wae(fweflll!(#)')).toEqual(false);
             expect(renderer._isNeedEscape('[#awefawefwae]! (awefwaef)[waefawef]')).toEqual(false);
+        });
+    });
+
+    it('_isNeedEscapeHtml() can check passed text is needed escape or not', function() {
+        var renderer;
+
+        beforeEach(function() {
+            renderer = Renderer.factory();
+        });
+
+        it('valid html', function() {
+            expect(renderer._isNeedEscapeHtml('<span>')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<span >')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<span />')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<SPAN>')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('</span>')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<span-custom>')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<span attr="value">')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<prefix:span>')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<span.dot>')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<!-- comment -->')).toEqual(true);
+        });
+
+        it('valid common-mark autolink', function() {
+            expect(renderer._isNeedEscapeHtml('<http://google.com>')).toEqual(true);
+            expect(renderer._isNeedEscapeHtml('<mailto:foo@bar.baz>')).toEqual(true);
+        });
+
+        it('invalid html or autolink', function() {
+            expect(renderer._isNeedEscapeHtml('<\\span>')).toEqual(false);
+            expect(renderer._isNeedEscapeHtml('</ span>')).toEqual(false);
+            expect(renderer._isNeedEscapeHtml('</span attr="value">')).toEqual(false);
+            expect(renderer._isNeedEscapeHtml('< span>')).toEqual(false);
+            expect(renderer._isNeedEscapeHtml('<span/ >')).toEqual(false);
+            expect(renderer._isNeedEscapeHtml('<http://foo.bar/baz bim>')).toEqual(false);
+            expect(renderer._isNeedEscapeHtml('<http://example.com/\\[>')).toEqual(false);
         });
     });
 


### PR DESCRIPTION
# Escaping <
## Candidate Regex
```js
/<([a-zA-Z_][a-zA-Z0-9\-\._]*)(\s|[^\\/>])*\/?>|<(\/)([a-zA-Z_][a-zA-Z0-9\-\._]*)\s*\/?>|<!--[^-]+-->|<([a-zA-Z_][a-zA-Z0-9\-\.:/]*)>/
```

## Escape valid html tags
* \<span> // valid start tag
* \<span > // valid starat tag with trailing space
* \<span/> // valid self containing tag
* \<SPAN /> // upper case
* \</SPAN> // valid end tag
* \</SPAN  > // valid end tag with trailing space
* \<asdf059 > // tag name can have numeric characters
* \<asdf-asdf> // tag name can have 'dash'
* \<span someattr="somevalue"> // start tag with attributes
* \<ns:span > // tag name contains colon
* \<some.tag > // tag name contains dot
* \<!--  --> // comment

---
## Escape Common-mark AutoLink
* \<http://www.google.com> // common-mark autolink url
* \<mailto:@bar.baz>
* \<irc://foo.bar:2233/baz>
* \<localhost:5001/foo>

---
# No Escape
* <\span> // no back slash
* </ span> // no space between slash and tag name in end tag
* \</span attr="value"> // no attributes in end tag, `common-mark & markdown-it disallow, but github allows`
* < span> // no space before tag name
* \<span/ > // no space between slash and rt `common-mark & markdown-it disallow, but github allows`
* \<http://foo.bar/baz bim> // no space in autolink `common-mark & markdown-it disallow, but github allows`
* <http://example.com/\[\> // no backslash in autolink

---
# Caveat
## 아래와 같은 경우는 현재 처리 불가능한 이슈입니다.
* 여러 줄에 걸쳐 html 태크가 완성되는 경우
```html
<a
 >
```
* 태그 속성값에 정규식을 해치는 문자가 들어있는 경우
```html
<span attr="\\[]<>\"">
```
* html 스펙에는 허용하는 문자이나 통상 쓰이지 않는 문자로 태그, 속성 이름이 들어가 있는 경우
`Ö, Ø, Ù`등