### PR TITLE
normalize text nodes

### DIFF
--- a/src/domRunner.js
+++ b/src/domRunner.js
@@ -97,7 +97,16 @@ DomRunner.prototype._isNeedNextSearch = function(node, current) {
  * @returns {node} next node
  */
 DomRunner.prototype._getNextNode = function(current) {
-    return current.firstChild || current.nextSibling;
+    var node = current.firstChild || current.nextSibling;
+
+    if (node && node.nodeType === NODE.TEXT_NODE) {
+        while (node.nextSibling && node.nextSibling.nodeType === NODE.TEXT_NODE) {
+            node.nodeValue += node.nextSibling.nodeValue;
+            node.parentNode.removeChild(node.nextSibling);
+        }
+    }
+
+    return node;
 };
 
 DomRunner.NODE_TYPE = NODE;

--- a/test/domRunner.spec.js
+++ b/test/domRunner.spec.js
@@ -358,4 +358,16 @@ describe('domRunner', function() {
             expect(domRunner.next()).toBeNull();
         });
     });
+
+    describe('normalize text nodes', function() {
+        beforeEach(function() {
+            var dom = toDom('test -');
+            dom.appendChild(document.createTextNode('text'));
+            domRunner = new DomRunner(dom);
+        });
+
+        it('domRunner returns normalized node', function() {
+            expect(domRunner.next().nodeValue).toBe('test -text');
+        });
+    });
 });


### PR DESCRIPTION
To make a normalized text `Node.normalize` will do the job.
but IE11 has a bug, does not normalize text if text has some text like `-` occasionally.

Manually concatenate texts iterating sibling text nodes.

#3 